### PR TITLE
Fix rest-doclet for endpoints with an array in RequestBody

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ rest-doclet
 
 The purpose of this README file is to explain how one can easily generate Spring mvc based REST API documentation.
 
+For specific information on how to set up rest-doclet for Mediagraft, see [the Mediagraft Wiki](http://wiki.blinkboxmusic.com/core/mediagraft/restdoclet).
+
 The rest-doclet enables automatic generation of documentation from REST service source code, and displays spring-annotated service operations, types and associated Javadoc.
 The detection of Spring artifacts is based on the presence of Spring annotations on Java classes and methods.
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ allprojects {
   targetCompatibility = 1.6
 
   group = 'org.cloudifysource'
-  version = '0.5.28'
+  version = '0.5.29'
 
   task sourceJar(type: Jar) {
     classifier = 'sources'


### PR DESCRIPTION
REST document generation was failing for UserController.updateGenrePreferences(), which is mapped by a POST request to /users/{id}/library/genres
This is currently the only REST endpoint that requires an array in the request body.

The failure was occurring in generating the example for the call. It occurred because the parameter processing code removed the specialisation from the List<>, causing later code to generate an example list containing a bare Object, which cannot be serialised.

This fix preserves the specialisation, as already happens in the code that handles the endpoint response, so that later code works correctly.

!bug MUSAPI-314

!test
Run "gradle clean generateRestDocs" and check that the documentation is generated correctly.
If you are using the default setup, the documentation will be generated into: <api checkout directory>/build/rest-docs/index.html