### PR TITLE
Allow annotation to set the response json for a class

### DIFF
--- a/annotations/src/main/java/org/cloudifysource/restDoclet/annotations/JsonResponseExample.java
+++ b/annotations/src/main/java/org/cloudifysource/restDoclet/annotations/JsonResponseExample.java
@@ -15,45 +15,41 @@
  *******************************************************************************/
 package org.cloudifysource.restDoclet.annotations;
 
-import java.lang.annotation.Documented;
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
+import java.lang.annotation.*;
 
 
 /**
- * <p> Annotation to specify an example of a JSON response.<br />
+ * <p>Annotation to specify an example of a JSON response.<br>
  * Should be use within the REST's controllers above requestMapping methods 
  * to specify an example that will be shown in the REST API documentation.</p>
  * 
  * <p>For example:
  * <dd><code>JsonResponseExample(status = "success",
  *  responseBody = "{Json map content}", comments = "some comments")</code></p>
- * 
+ *
+ * <p>Or it can be used on a response class to override the normal response
+ * object generation (via reflection) with the specified response body.</p>
  * 
  * @author yael
  *
  */
-@Target({ElementType.METHOD })
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface JsonResponseExample {
 	
 	/**
-	 * 
 	 * The status.
-	 * 
 	 */
-	String status();
+	String status() default "";
 	
 	/**
-	 * 
 	 * The response.
 	 */
 	String responseBody() default "{}";
 	
 	/**
-	 * 
 	 * Comments to describe the response's body.
-	 * 
 	 */
 	String comments() default "";
 }

--- a/src/main/java/org/cloudifysource/restDoclet/exampleGenerators/ObjectCreator.java
+++ b/src/main/java/org/cloudifysource/restDoclet/exampleGenerators/ObjectCreator.java
@@ -35,9 +35,10 @@ public abstract class ObjectCreator {
     return name.substring(0, 1).toLowerCase() + name.substring(1);
   }
 
-  public ObjectCreator() {
-    exampleCreators_ = newArrayList(primitiveCreator_, wrapperCreator_, stringCreator_, enumCreator_,
-        dateCreator_, calendarCreator_, arrayCreator_, listCreator_, setCreator_, mapCreator_);
+  public ObjectCreator(ExampleCreator... creators) {
+    exampleCreators_ = newArrayList(creators);
+    exampleCreators_.addAll(newArrayList(primitiveCreator_, wrapperCreator_, stringCreator_,
+        enumCreator_, dateCreator_, calendarCreator_, arrayCreator_, listCreator_, setCreator_, mapCreator_));
   }
 
   public Object createObject(final ObjectType objectType) throws Exception {
@@ -139,7 +140,7 @@ public abstract class ObjectCreator {
     }
   };
 
-  private ExampleCreator dateCreator_ = new ExampleCreator() {
+  private static ExampleCreator dateCreator_ = new ExampleCreator() {
     @Override
     public boolean match(final Class cls) {
       return Date.class.isAssignableFrom(cls);
@@ -151,7 +152,7 @@ public abstract class ObjectCreator {
     }
   };
 
-  private ExampleCreator calendarCreator_ = new ExampleCreator() {
+  private static ExampleCreator calendarCreator_ = new ExampleCreator() {
     @Override
     public boolean match(final Class cls) {
       return Calendar.class.isAssignableFrom(cls);

--- a/src/main/java/org/cloudifysource/restDoclet/exampleGenerators/ResponseObjectCreator.java
+++ b/src/main/java/org/cloudifysource/restDoclet/exampleGenerators/ResponseObjectCreator.java
@@ -2,9 +2,11 @@ package org.cloudifysource.restDoclet.exampleGenerators;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.lang.reflect.Type;
 import java.util.Map;
 import java.util.logging.Logger;
+
+import org.cloudifysource.restDoclet.annotations.JsonResponseExample;
+import org.codehaus.jackson.map.ObjectMapper;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -13,6 +15,10 @@ public class ResponseObjectCreator extends ObjectCreator {
   private static final Logger LOGGER = Logger.getLogger(ResponseObjectCreator.class.getName());
 
   private static final String[] PREFIXES = {"get", "is"};
+
+  public ResponseObjectCreator() {
+    super(responseExampleCreator_);
+  }
 
   @Override
   protected Map<String, ObjectType> getProperties(final Class cls) {
@@ -31,4 +37,19 @@ public class ResponseObjectCreator extends ObjectCreator {
 
     return properties;
   }
+
+  private static ExampleCreator responseExampleCreator_ = new ExampleCreator() {
+    @Override
+    public boolean match(final Class cls) {
+      return cls.getAnnotation(JsonResponseExample.class) != null;
+    }
+
+    @Override
+    public Object create(final Class cls, final ObjectType type) throws Exception {
+      final JsonResponseExample annotation = (JsonResponseExample) cls.getAnnotation(JsonResponseExample.class);
+      final String body = annotation.responseBody().trim();
+      final Object example = new ObjectMapper().readTree(body);
+      return example;
+    }
+  };
 }

--- a/src/test/java/org/cloudifysource/restDoclet/exampleGenerators/RequestObjectCreatorTest.java
+++ b/src/test/java/org/cloudifysource/restDoclet/exampleGenerators/RequestObjectCreatorTest.java
@@ -3,15 +3,14 @@ package org.cloudifysource.restDoclet.exampleGenerators;
 import java.lang.reflect.Method;
 import java.util.*;
 
+import org.cloudifysource.restDoclet.annotations.JsonResponseExample;
+import org.codehaus.jackson.node.ObjectNode;
+import org.hamcrest.CoreMatchers;
 import org.junit.Before;
 import org.junit.Test;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.*;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import static com.google.common.collect.Lists.newArrayList;
@@ -166,6 +165,14 @@ public class RequestObjectCreatorTest {
   }
 
   @Test
+  public void doesNotCreateClassWithResponseExampleAnnotation() throws Exception {
+    final Object outer = creator_.createObject(new ObjectType(ClassWithResponseExample.class));
+    final Object inner = callMethod(outer, "getExample", Object.class);
+    assertThat(inner, notNullValue());
+    assertHasMethod(inner, "getCount");
+  }
+
+  @Test
   public void canCreateATopLevelList() throws Exception {
     final List<String> stringList = newArrayList();
     final Object listObject = creator_.createObject(new ObjectType(stringList.getClass()));
@@ -310,6 +317,17 @@ public class RequestObjectCreatorTest {
 
     class Inner {
       public void setCount(Integer count) {
+      }
+    }
+  }
+
+  static class ClassWithResponseExample {
+    public void setExample(Example example) {
+    }
+
+    @JsonResponseExample(responseBody = "{\"override\": true}")
+    static class Example {
+      public void setCount(int count) {
       }
     }
   }

--- a/src/test/java/org/cloudifysource/restDoclet/exampleGenerators/ResponseObjectCreatorTest.java
+++ b/src/test/java/org/cloudifysource/restDoclet/exampleGenerators/ResponseObjectCreatorTest.java
@@ -3,9 +3,12 @@ package org.cloudifysource.restDoclet.exampleGenerators;
 import java.lang.reflect.Method;
 import java.util.*;
 
+import org.cloudifysource.restDoclet.annotations.JsonResponseExample;
+import org.codehaus.jackson.node.ObjectNode;
 import org.junit.Before;
 import org.junit.Test;
 
+import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.isA;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -169,6 +172,16 @@ public class ResponseObjectCreatorTest {
   }
 
   @Test
+  public void canCreateClassWithExampleAnnotation() throws Exception {
+    final Object outer = creator_.createObject(new ObjectType(ClassWithResponseExample.class));
+    final Object inner = callMethod(outer, "getExample", Object.class);
+    assertThat(inner, notNullValue());
+    assertThat(inner, instanceOf(ObjectNode.class));
+    assertThat(((ObjectNode) inner).get("count"), nullValue());
+    assertThat(((ObjectNode) inner).get("override").asText(), is("true"));
+  }
+
+  @Test
   public void canCreateATopLevelList() throws Exception {
     final List<String> stringList = newArrayList();
     final Object listObject = creator_.createObject(new ObjectType(stringList.getClass()));
@@ -212,10 +225,8 @@ public class ResponseObjectCreatorTest {
   }
 
   static class ClassWithAnAbstractClassInside {
-    private AbstractClass abstractClass_;
-
     public AbstractClass getTheAbstractClass() {
-      return abstractClass_;
+      return null;
     }
   }
 
@@ -224,55 +235,42 @@ public class ResponseObjectCreatorTest {
   }
 
   static abstract class AbstractClass {
-    private String bar_;
-
     public abstract String getFoo();
   }
 
   static class Fish {
-    private String name_;
-    private long count_;
-    private boolean saltwater_;
-    private Integer temp_;
-
     public String getName() {
-      return name_;
+      return null;
     }
 
     public long getCount() {
-      return count_;
+      return 0;
     }
 
     public boolean isSaltwater() {
-      return saltwater_;
+      return false;
     }
 
     public Integer getTemp() {
-      return temp_;
+      return 0;
     }
   }
 
   static class FishBowl {
-    private Fish fish_;
-
     public Fish getFish() {
-      return fish_;
+      return null;
     }
   }
 
   static class Aquarium {
-    private List<Fish> fishes_;
-
     public List<Fish> getFishes() {
-      return fishes_;
+      return null;
     }
   }
 
   static class SeaWorld {
-    private List<Aquarium> aquariums_;
-
     public List<Aquarium> getAquariums()  {
-      return aquariums_;
+      return null;
     }
   }
 
@@ -282,54 +280,55 @@ public class ResponseObjectCreatorTest {
       PENDING
     }
 
-    private Status status_;
-
     public Status getStatus() {
-      return status_;
+      return null;
     }
   }
 
   static class ClassWithDate {
-    private Date date_;
-
     public Date getDate() {
-      return date_;
+      return null;
     }
   }
 
   static class ClassWithCalendar {
-    private Calendar calendar_;
-
     public Calendar getCalendar() {
-      return calendar_;
+      return null;
     }
   }
 
   static class ClassWithMap {
-    Map<Long, String> hashMap_ ;
-
     public Map<Long, String> getMap() {
-      return hashMap_;
+      return null;
     }
   }
 
   static class ClassWithSet {
-    Set<String> hashSet_;
-
     public Set<String> getSet() {
-      return hashSet_;
+      return null;
     }
   }
 
   static class ClassWithNestedInnerClass {
-    private Inner inner_;
-
     public Inner getInner() {
-      return inner_;
+      return null;
     }
 
     class Inner {
       public Integer getCount() {
+        return 0;
+      }
+    }
+  }
+
+  static class ClassWithResponseExample {
+    public Example getExample() {
+      return null;
+    }
+
+    @JsonResponseExample(responseBody = "{\"override\": true}")
+    static class Example {
+      public int getCount() {
         return 0;
       }
     }


### PR DESCRIPTION
The JsonResponseExample annotation has been extended to allow it to
be set on classes where the JSON response body that it contains is
used to represent the class in the documentation instead of that
generated by reflection.

!BUG: MUSAPI-158
!TESTS:
Until the annotation is used, no chage in documentation should be
observed.