### PR TITLE
Take notice of @JsonIgnore and @JsonProperty annotations on methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ allprojects {
   targetCompatibility = 1.8
 
   group = 'org.cloudifysource'
-  version = '0.5.33'
+  version = '0.5.34'
 
   task sourceJar(type: Jar) {
     classifier = 'sources'

--- a/src/main/java/org/cloudifysource/restDoclet/exampleGenerators/RequestObjectCreator.java
+++ b/src/main/java/org/cloudifysource/restDoclet/exampleGenerators/RequestObjectCreator.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import static com.google.common.collect.Maps.newHashMap;
@@ -40,8 +41,17 @@ public class RequestObjectCreator extends ObjectCreator {
             && m.getName().startsWith("set")
             && m.getName().length() > 3
             && m.getParameterTypes().length == 1
+            && m.getAnnotation(JsonIgnore.class) == null
             && !OBJECT_METHODS.contains(m.getName())) {
-          properties.put(uncapitalize(m.getName().substring(3)), new ObjectType(m.getGenericParameterTypes()[0]));
+          final String name;
+          final JsonProperty annotation = m.getAnnotation(JsonProperty.class);
+          if (annotation != null) {
+            name = annotation.value();
+          }
+          else {
+            name = m.getName().substring(3);
+          }
+          properties.put(uncapitalize(name), new ObjectType(m.getGenericParameterTypes()[0]));
         }
       }
     }

--- a/src/main/java/org/cloudifysource/restDoclet/exampleGenerators/ResponseObjectCreator.java
+++ b/src/main/java/org/cloudifysource/restDoclet/exampleGenerators/ResponseObjectCreator.java
@@ -8,6 +8,9 @@ import java.util.logging.Logger;
 import org.cloudifysource.restDoclet.annotations.JsonResponseExample;
 import org.codehaus.jackson.map.ObjectMapper;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import static com.google.common.collect.Maps.newHashMap;
 
 public class ResponseObjectCreator extends ObjectCreator {
@@ -25,10 +28,22 @@ public class ResponseObjectCreator extends ObjectCreator {
     final Map<String, ObjectType> properties = newHashMap();
 
     for (Method m : cls.getMethods()) {
-      if (Modifier.isPublic(m.getModifiers()) && m.getParameterTypes().length == 0 && !OBJECT_METHODS.contains(m.getName())) {
+      if (Modifier.isPublic(m.getModifiers())
+          && m.getParameterTypes().length == 0
+          && m.getAnnotation(JsonIgnore.class) == null
+          &&!OBJECT_METHODS.contains(m.getName())) {
         for (String prefix : PREFIXES) {
-          if (m.getName().startsWith(prefix) && m.getName().length() > prefix.length()) {
-            properties.put(uncapitalize(m.getName().substring(prefix.length())), new ObjectType(m.getGenericReturnType()));
+          if (m.getName().startsWith(prefix)
+              && m.getName().length() > prefix.length()) {
+            String name;
+            final JsonProperty annotation = m.getAnnotation(JsonProperty.class);
+            if (annotation != null) {
+              name = annotation.value();
+            }
+            else {
+              name = m.getName().substring(prefix.length());
+            }
+            properties.put(uncapitalize(name), new ObjectType(m.getGenericReturnType()));
             break;
           }
         }

--- a/src/main/java/org/cloudifysource/restDoclet/generation/Generator.java
+++ b/src/main/java/org/cloudifysource/restDoclet/generation/Generator.java
@@ -300,13 +300,11 @@ public class Generator {
       DocController controller = new DocController(controllerClassName);
 
       SortedMap<String, DocMethod> generatedMethods = generateMethods(classDoc.methods());
-      if (!generatedMethods.isEmpty()) {
-        controller.setMethods(generatedMethods);
-        controller.setUri(uri);
-        controller.setDescription(classDoc.commentText());
+      controller.setMethods(generatedMethods);
+      controller.setUri(uri);
+      controller.setDescription(classDoc.commentText());
 
-        controllers.add(controller);
-      }
+      controllers.add(controller);
     }
     return controllers;
   }


### PR DESCRIPTION
Also allow a controller with no methods to appear in the documentation.

!BUG: MUSAPI-158
!TESTS:
No change in documentation until the genre tags response has had
@JsonProperty added to it when the documentation for GET /genreTags
should report a field called genre_id instead of genreId.

The MaintenanceController should be documented although without any
endpoints being listed.